### PR TITLE
[新增錯誤訊息／串接admin驗證api] Feature/AP- login_register_admin_err msg

### DIFF
--- a/src/Api/AdminAPI.js
+++ b/src/Api/AdminAPI.js
@@ -35,10 +35,9 @@ export const adminLogin = async ({ account, password }) => {
 
     return data;
   } catch (error) {
-    // 待後端
     console.error("[Admin login Failed]:", error);
-    //const errMsg = error.response.data.message
-    //return errMsg
+    const errCode = error.response.data.status
+    return { success: false, errCode: errCode };
   }
 };
 

--- a/src/Api/AuthAPI.js
+++ b/src/Api/AuthAPI.js
@@ -17,6 +17,8 @@ export const login = async ({ account, password }) => {
     return data;
   } catch (error) {
     console.error("[Login Failed]:", error);
+    const errCode = error.response.data.status
+    return { success: false, errCode: errCode };
   }
 };
 
@@ -44,6 +46,8 @@ export const register = async ({
     return data;
   } catch (error) {
     console.error("[Register Failed]:", error);
+    const errCode = error.response.data.status
+    return { success: false, errCode: errCode };
   }
 };
 

--- a/src/Api/AuthAPI.js
+++ b/src/Api/AuthAPI.js
@@ -63,3 +63,17 @@ export const checkPermission = async (token) => {
     console.error("[Check Permission Failed]:", error);
   }
 };
+
+// Admin check permission
+export const checkAdminPermission = async (token) => {
+  try {
+    const response = await axios.get(`${baseUrl}/auth/admin`, {
+      headers: {
+        Authorization: "Bearer " + token,
+      },
+    });
+    return response.data;
+  } catch (error) {
+    console.error("[Check Admin Permission Failed]:", error);
+  }
+};

--- a/src/Api/UserSettingAPI.js
+++ b/src/Api/UserSettingAPI.js
@@ -19,12 +19,9 @@ axiosInstance.interceptors.request.use(
   },
 );
 
-export const setUserData = async (payload) => {
-  const { id, account, name, email, password, checkPassword } = payload
+export const setUserData = async (id, formData) => {
   try {
-    const { data } = await axiosInstance.put(`${baseUrl}/${id}`, {
-      id, account, name, email, password, checkPassword
-    });
+    const { data } = await axiosInstance.put(`${baseUrl}/${id}`, formData)
 
     if (data) {
       return { success: true, ...data };

--- a/src/Api/UserSettingAPI.js
+++ b/src/Api/UserSettingAPI.js
@@ -34,33 +34,6 @@ export const setUserData = async (payload) => {
   } catch (error) {
     console.error("[Set User Failed]:", error);
     const errCode = error.response.data.status
-    let errMsg = ''
-
-    switch(errCode) {
-      case '422':
-        errMsg = '密碼長度不符或是確認密碼不相符'
-        break
-      case '403':
-        errMsg = '名稱字數超過上限'
-        break
-      case '401':
-        errMsg = 'email格式不符'
-        break
-      case '408':
-        errMsg = 'Email已重複註冊'
-        break
-      case '423':
-        errMsg = '帳號已重複註冊'
-        break
-      // 錯誤code重複待後端修正
-      // case '401':
-      //   return '您尚未登入'
-      case '500':
-        errMsg = '伺服器發生錯誤'
-        break
-      default:
-        errMsg = '發生未預期錯誤...'
-    }
-    return { success: false, errMsg: errMsg}
+    return { success: false, errCode: errCode };
   }
 };

--- a/src/Context/AuthContext.js
+++ b/src/Context/AuthContext.js
@@ -1,7 +1,7 @@
 import { createContext } from "react";
 import { useState, useEffect, useContext } from "react";
 import { useLocation } from 'react-router-dom';
-import { login, register, checkPermission } from '../Api/AuthAPI'
+import { login, register, checkPermission, checkAdminPermission } from '../Api/AuthAPI'
 
 // 設定一開始context 預設值
 const defaultValue = {
@@ -32,9 +32,8 @@ function AuthProvider(props) {
         setUserData(null);
         return;
       }
-    
+
       const result = await checkPermission(token);
-   
 
       if (result.status === '200') {
         setIsAuthenticated(true);
@@ -46,8 +45,29 @@ function AuthProvider(props) {
         setUserData(null);
       }
     };
+    // checkPermission for admin related page
+    const checkAdminTokenIsValid = async () => {
+      const token = localStorage.getItem('authToken');
+      if (!token) {
+        setIsAuthenticated(false);
+        setUserData(null);
+        return;
+      }
+
+      const result = await checkAdminPermission(token);
+
+      if (result.status === '200') {
+        setIsAuthenticated(true);
+
+      } else {
+        setIsAuthenticated(false);
+      }
+    }
     // admin related pages not applied  
-    if (!pathname.includes("/admin")) { checkTokenIsValid() };
+    if (pathname.includes("/admin")) { checkAdminTokenIsValid() } 
+    else {
+      checkTokenIsValid()
+    }
   }, [pathname]);
 
   return (

--- a/src/Context/AuthContext.js
+++ b/src/Context/AuthContext.js
@@ -32,7 +32,6 @@ function AuthProvider(props) {
         setUserData(null);
         return;
       }
-      // if ( token && role=== user) {}
     
       const result = await checkPermission(token);
    
@@ -58,7 +57,7 @@ function AuthProvider(props) {
         currentUser: userData,
         setCurrentUser: setUserData, //傳給編輯使用者資料相關頁面使用
         register: async (data) => {
-          const { success, token, user } = await register({
+          const { success, token, user, errCode } = await register({
             account: data.account,
             name: data.nameTrimmed,
             email: data.email,
@@ -70,10 +69,10 @@ function AuthProvider(props) {
             setUserData(user)
             localStorage.setItem('authToken', token);
           }
-          return success
+          return { success, errCode }
         },
         login: async (data) => {
-          const { success, token, user } = await login({
+          const { success, token, user, errCode } = await login({
             account: data.accountTrimmed,
             password: data.passwordTrimmed,
           });
@@ -82,7 +81,7 @@ function AuthProvider(props) {
             setUserData(user)
             localStorage.setItem('authToken', token);
           }
-          return success;
+          return { success, errCode }
         },
         logout: () => {
           localStorage.removeItem('authToken');

--- a/src/Pages/AdminLoginPage/index.jsx
+++ b/src/Pages/AdminLoginPage/index.jsx
@@ -1,9 +1,10 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { Link, useNavigate } from "react-router-dom";
 import { ReactComponent as AcLogo } from "../../assets/icons/AcLogo.svg";
 import AuthInput from "../../Components/AuthInput/index";
 import Button from "../../Components/Button";
 import { adminLogin } from "../../Api/AdminAPI";
+import { useAuth } from "../../Context/AuthContext";
 import styles from "./AdminLoginPage.module.scss";
 import { ToastSuccess, ToastFail } from "../../assets/sweetalert"; //引入Toast樣式
 
@@ -14,6 +15,8 @@ function AdminLoginPage() {
   const [submitting, setSubmitting] = useState(false);
   const [errCode, setErrCode] = useState("");
   const navigate = useNavigate();
+
+  const { isAuthenticated } = useAuth();
 
   // Alert message variant
   let accountAlertMsg = "";
@@ -65,6 +68,13 @@ function AdminLoginPage() {
     setSubmitting(false);
     setErrCode("");
   };
+
+  //if user is authenticated, navigate to tweetlist page
+  useEffect(() => {
+    if (isAuthenticated) {
+      navigate("/admin/tweetlist");
+    }
+  }, [navigate, isAuthenticated]);
 
   // 以下為錯誤驗證------------------------------
   // Input blank check

--- a/src/Pages/AdminLoginPage/index.jsx
+++ b/src/Pages/AdminLoginPage/index.jsx
@@ -5,13 +5,14 @@ import AuthInput from "../../Components/AuthInput/index";
 import Button from "../../Components/Button";
 import { adminLogin } from "../../Api/AdminAPI";
 import styles from "./AdminLoginPage.module.scss";
-import Swal from "sweetalert2";
+import { ToastSuccess, ToastFail } from "../../assets/sweetalert"; //引入Toast樣式
 
 function AdminLoginPage() {
   // State Variable
   const [account, setAccount] = useState("");
   const [password, setPassword] = useState("");
   const [submitting, setSubmitting] = useState(false);
+  const [errCode, setErrCode] = useState("");
   const navigate = useNavigate();
 
   // Alert message variant
@@ -29,7 +30,7 @@ function AdminLoginPage() {
       return;
     }
     // If all input value is valid
-    const { success, token } = await adminLogin({
+    const { success, token, errCode } = await adminLogin({
       account,
       password,
     });
@@ -37,31 +38,35 @@ function AdminLoginPage() {
     // 待後端把錯誤訊息補上補上實作錯誤訊息
     if (success) {
       localStorage.setItem("authToken", token);
-      Swal.fire({
-        title: "Success!",
-        icon: "success",
-        showConfirmButton: false,
-        timer: 1000,
-        position: "top",
+      ToastSuccess.fire({
+        title: "登入成功！",
       });
       navigate("/admin/tweetlist");
       return;
-    } else {
-      Swal.fire({
-        title: "Failed...",
-        icon: "error",
-        showConfirmButton: false,
-        timer: 1000,
-        position: "top",
+    }
+    //登入失敗
+    //如果是非input欄顯示的錯誤，跳出訊息
+    if (errCode === 400) {
+      ToastFail.fire({
+        title: "有空白欄位！",
       });
+    } else if (!errCode) {
+      ToastFail.fire({
+        title: "發生未預期錯誤...",
+      });
+    } else {
+      // input欄顯示錯誤在click function外處理，所以需將errCode存起來
+      setErrCode(errCode);
     }
   };
 
   // When user focus on the input clear the alert message
   const handleFocus = () => {
     setSubmitting(false);
+    setErrCode("");
   };
 
+  // 以下為錯誤驗證------------------------------
   // Input blank check
   if (submitting && accountLength === 0) {
     accountAlertMsg = "此欄為必填欄位";
@@ -69,6 +74,17 @@ function AdminLoginPage() {
 
   if (submitting && passwordLength === 0) {
     passwordAlertMsg = "此欄為必填欄位";
+  }
+
+  //後端驗證錯誤（input欄位顯示）
+  //when the account does not exist
+  if (errCode === 423) {
+    accountAlertMsg = "帳號不存在";
+  }
+
+  //when invalid password
+  if (errCode === 402) {
+    passwordAlertMsg = "密碼錯誤";
   }
 
   return (

--- a/src/Pages/AdminTweetPage/index.jsx
+++ b/src/Pages/AdminTweetPage/index.jsx
@@ -1,9 +1,11 @@
 import { useState, useEffect } from "react";
+import { useNavigate } from "react-router-dom";
 import { ReactComponent as AdminDeleteIcon } from "../../assets/icons/admin_delete_icon.svg";
 import UserInfo from "../../Components/UserTweetBox/UserInfo";
 import styles from "./AdminTweetPage.module.scss";
 import { TimeFromNow } from "../../CostumHook/TransFormDate";
 import { adminDeleteTweet, adminGetAllTweets } from "../../Api/AdminAPI";
+import { useAuth } from "../../Context/AuthContext";
 import Swal from "sweetalert2";
 
 function AdminTweetBox(props) {
@@ -50,6 +52,9 @@ function AdminTweetBox(props) {
 function AdminTweetPage() {
   const [tweetList, setTweetList] = useState([]);
   const [deleteTrigger, setDeleteTrigger] = useState(false); //delete function是否被觸發
+  const navigate = useNavigate();
+
+  const { isAuthenticated } = useAuth();
 
   const getAllTweetsAsync = async () => {
     try {
@@ -76,6 +81,13 @@ function AdminTweetPage() {
       console.error(error);
     }
   };
+
+  //if user is not authenticated, navigate to login page
+  useEffect(() => {
+    if (!isAuthenticated) {
+      navigate("/admin");
+    }
+  }, [navigate, isAuthenticated]);
 
   useEffect(() => {
     getAllTweetsAsync();

--- a/src/Pages/AdminTweetPage/index.jsx
+++ b/src/Pages/AdminTweetPage/index.jsx
@@ -6,7 +6,7 @@ import styles from "./AdminTweetPage.module.scss";
 import { TimeFromNow } from "../../CostumHook/TransFormDate";
 import { adminDeleteTweet, adminGetAllTweets } from "../../Api/AdminAPI";
 import { useAuth } from "../../Context/AuthContext";
-import { ToastSuccess, ToastFail } from "../../assets/sweetalert"; //引入Toast樣
+import { ToastSuccess, ToastFail } from "../../assets/sweetalert"; //引入Toast樣式
 
 function AdminTweetBox(props) {
   //須從後端傳入的資料
@@ -84,6 +84,9 @@ function AdminTweetPage() {
   //if user is not authenticated, navigate to login page
   useEffect(() => {
     if (!isAuthenticated) {
+      ToastFail.fire({
+        title: "帳號不存在！",
+      });
       navigate("/admin");
     }
   }, [navigate, isAuthenticated]);

--- a/src/Pages/AdminTweetPage/index.jsx
+++ b/src/Pages/AdminTweetPage/index.jsx
@@ -6,7 +6,7 @@ import styles from "./AdminTweetPage.module.scss";
 import { TimeFromNow } from "../../CostumHook/TransFormDate";
 import { adminDeleteTweet, adminGetAllTweets } from "../../Api/AdminAPI";
 import { useAuth } from "../../Context/AuthContext";
-import Swal from "sweetalert2";
+import { ToastSuccess, ToastFail } from "../../assets/sweetalert"; //引入Toast樣
 
 function AdminTweetBox(props) {
   //須從後端傳入的資料
@@ -70,15 +70,14 @@ function AdminTweetPage() {
     try {
       await adminDeleteTweet(id);
       setDeleteTrigger(true);
-      Swal.fire({
+      ToastSuccess.fire({
         title: "刪除成功",
-        icon: "success",
-        showConfirmButton: false,
-        timer: 1000,
-        position: "top",
       });
     } catch (error) {
       console.error(error);
+      ToastFail.fire({
+        title: "刪除失敗...",
+      });
     }
   };
 

--- a/src/Pages/AdminUserPage/index.jsx
+++ b/src/Pages/AdminUserPage/index.jsx
@@ -1,8 +1,10 @@
 import { useState, useEffect } from "react";
+import { useNavigate } from "react-router-dom";
 import styles from "./AdminUserPage.module.scss";
 import { ReactComponent as TweetFeather } from "../../assets/icons/tweet_feather_icon.svg";
 import { ReactComponent as LikeIcon } from "../../assets/icons/like_icon.svg";
 import { adminGetAllUsers } from "../../Api/AdminAPI";
+import { useAuth } from "../../Context/AuthContext";
 
 function AdminUserCard(props) {
   const {
@@ -52,12 +54,23 @@ function AdminUserCard(props) {
 
 function AdminUserPage() {
   const [userList, setUserList] = useState([]);
+  const navigate = useNavigate();
+
+  const { isAuthenticated } = useAuth();
+
+  //if user is authenticated, navigate to tweetlist page
+  useEffect(() => {
+    if (!isAuthenticated) {
+      navigate("/admin");
+      return
+    }
+  }, [navigate, isAuthenticated]);
 
   useEffect(() => {
     const getAllUsersAsync = async () => {
       try {
         const res = await adminGetAllUsers();
-        setUserList(res.filter(data => data.role !== "admin"));
+        setUserList(res.filter((data) => data.role !== "admin"));
       } catch (error) {
         console.log(error);
       }

--- a/src/Pages/AdminUserPage/index.jsx
+++ b/src/Pages/AdminUserPage/index.jsx
@@ -5,6 +5,7 @@ import { ReactComponent as TweetFeather } from "../../assets/icons/tweet_feather
 import { ReactComponent as LikeIcon } from "../../assets/icons/like_icon.svg";
 import { adminGetAllUsers } from "../../Api/AdminAPI";
 import { useAuth } from "../../Context/AuthContext";
+import { ToastFail } from "../../assets/sweetalert"; //引入Toast樣式
 
 function AdminUserCard(props) {
   const {
@@ -61,6 +62,9 @@ function AdminUserPage() {
   //if user is authenticated, navigate to tweetlist page
   useEffect(() => {
     if (!isAuthenticated) {
+      ToastFail.fire({
+        title: "帳號不存在！",
+      });
       navigate("/admin");
       return
     }

--- a/src/Pages/LoginPage/index.jsx
+++ b/src/Pages/LoginPage/index.jsx
@@ -6,13 +6,14 @@ import { useAuth } from "../../Context/AuthContext";
 
 import Button from "../../Components/Button";
 import styles from "./LoginPage.module.scss";
-import Swal from "sweetalert2";
+import { ToastSuccess, ToastFail } from "../../assets/sweetalert"; //引入Toast樣式
 
 function LoginPage() {
   // State Variable
   const [account, setAccount] = useState("");
   const [password, setPassword] = useState("");
   const [submitting, setSubmitting] = useState(false);
+  const [errCode, setErrCode] = useState("");
   const navigate = useNavigate();
 
   const { login, isAuthenticated } = useAuth();
@@ -35,33 +36,39 @@ function LoginPage() {
     // refactor the value of account and password
     const accountTrimmed = account.trim();
     const passwordTrimmed = password.trim();
-    const success = await login({ accountTrimmed, passwordTrimmed });
+    const { success, errCode } = await login({
+      accountTrimmed,
+      passwordTrimmed,
+    });
 
-    // 待後端把錯誤訊息補上補上實作錯誤訊息
+    //登入成功
     if (success) {
-      Swal.fire({
-        title: "Success!",
-        icon: "success",
-        showConfirmButton: false,
-        timer: 1000,
-        position: "top",
+      ToastSuccess.fire({
+        title: "登入成功！",
       });
       navigate("/home");
       return;
-    } else {
-      Swal.fire({
-        title: "Failed...",
-        icon: "error",
-        showConfirmButton: false,
-        timer: 1000,
-        position: "top",
+    }
+    //登入失敗
+    //如果是非input欄顯示的錯誤，跳出訊息
+    if (errCode === 400) {
+      ToastFail.fire({
+        title: "有空白欄位",
       });
+    } else if (!errCode) {
+      ToastFail.fire({
+        title: "發生未預期錯誤...",
+      });
+    } else {
+    // input欄顯示錯誤在click function外處理，所以需將errCode存起來
+      setErrCode(errCode);
     }
   };
 
   // When user focus on the input clear the alert message
   const handleFocus = () => {
     setSubmitting(false);
+    setErrCode("");
   };
 
   //if user is authenticated, navigate to home page
@@ -71,13 +78,25 @@ function LoginPage() {
     }
   }, [navigate, isAuthenticated]);
 
+  // 前端驗證錯誤
   // Input blank check
-  if (submitting && accountLength === 0) {
+  if (submitting && accountLength === 0 ) {
     accountAlertMsg = "此欄為必填欄位";
   }
 
   if (submitting && passwordLength === 0) {
     passwordAlertMsg = "此欄為必填欄位";
+  }
+
+  //後端驗證錯誤（input欄位顯示）
+  //when the account does not exist
+  if (errCode === 423) {
+    accountAlertMsg = "帳號不存在";
+  }
+
+  //when invalid password
+  if (errCode === 402) {
+    passwordAlertMsg = "密碼錯誤";
   }
 
   return (

--- a/src/Pages/LoginPage/index.jsx
+++ b/src/Pages/LoginPage/index.jsx
@@ -53,7 +53,7 @@ function LoginPage() {
     //如果是非input欄顯示的錯誤，跳出訊息
     if (errCode === 400) {
       ToastFail.fire({
-        title: "有空白欄位",
+        title: "有空白欄位！",
       });
     } else if (!errCode) {
       ToastFail.fire({

--- a/src/Pages/LoginPage/index.jsx
+++ b/src/Pages/LoginPage/index.jsx
@@ -60,7 +60,7 @@ function LoginPage() {
         title: "發生未預期錯誤...",
       });
     } else {
-    // input欄顯示錯誤在click function外處理，所以需將errCode存起來
+      // input欄顯示錯誤在click function外處理，所以需將errCode存起來
       setErrCode(errCode);
     }
   };
@@ -78,9 +78,9 @@ function LoginPage() {
     }
   }, [navigate, isAuthenticated]);
 
-  // 前端驗證錯誤
+  // 以下為錯誤驗證------------------------------
   // Input blank check
-  if (submitting && accountLength === 0 ) {
+  if (submitting && accountLength === 0) {
     accountAlertMsg = "此欄為必填欄位";
   }
 
@@ -98,6 +98,8 @@ function LoginPage() {
   if (errCode === 402) {
     passwordAlertMsg = "密碼錯誤";
   }
+
+  // 以上為錯誤驗證------------------------------
 
   return (
     <div className={styles["container"]}>

--- a/src/Pages/RegisterPage/index.jsx
+++ b/src/Pages/RegisterPage/index.jsx
@@ -5,7 +5,7 @@ import AuthInput from "../../Components/AuthInput";
 import { useAuth } from "../../Context/AuthContext";
 import Button from "../../Components/Button";
 import styles from "./RegisterPage.module.scss";
-import Swal from "sweetalert2";
+import { ToastSuccess, ToastFail } from "../../assets/sweetalert"; //引入Toast樣式
 
 function RegisterPage() {
   // State Variable
@@ -15,6 +15,7 @@ function RegisterPage() {
   const [password, setPassword] = useState("");
   const [checkPassword, setCheckPassword] = useState("");
   const [submitting, setSubmitting] = useState(false);
+  const [errCode, setErrCode] = useState("");
   const navigate = useNavigate();
 
   const { register, isAuthenticated } = useAuth();
@@ -68,7 +69,7 @@ function RegisterPage() {
     // If all input value is valid
     // refactor the value of account and password
     const nameTrimmed = name.trim();
-    const success = await register({
+    const { success, errCode } = await register({
       account,
       nameTrimmed,
       email,
@@ -76,30 +77,34 @@ function RegisterPage() {
       checkPassword,
     });
 
+    // 註冊成功
     if (success) {
-      Swal.fire({
-        title: "Success!",
-        icon: "success",
-        showConfirmButton: false,
-        timer: 1000,
-        position: "top",
+      ToastSuccess.fire({
+        title: "註冊成功",
       });
       navigate("/home");
       return;
-    } else {
-      Swal.fire({
-        title: "Failed...",
-        icon: "error",
-        showConfirmButton: false,
-        timer: 1000,
-        position: "top",
+    }
+    //註冊失敗
+    //如果是非input欄顯示的錯誤，跳出訊息
+    if (errCode === 402) {
+      ToastFail.fire({
+        title: "有空白欄位！",
       });
+    } else if (!errCode) {
+      ToastFail.fire({
+        title: "發生未預期錯誤...",
+      });
+    } else {
+      // input欄顯示錯誤在click function外處理，所以需將errCode存起來
+      setErrCode(errCode);
     }
   };
 
   // When user focus on the input clear the alert message
   const handleFocus = () => {
     setSubmitting(false);
+    setErrCode("");
   };
 
   //if user is authenticated, navigate to home page
@@ -109,6 +114,7 @@ function RegisterPage() {
     }
   }, [navigate, isAuthenticated]);
 
+  // 以下為錯誤驗證------------------------------
   // Input blank check
   if (submitting && accountLength === 0) {
     accountAlertMsg = "此欄為必填欄位";
@@ -140,36 +146,48 @@ function RegisterPage() {
   }
 
   // Word length limit alert
-  if (accountLength > accountLengthLimit) {
+  if (accountLength > accountLengthLimit || errCode === 403) {
     accountAlertMsg = "帳號字數超出上限";
   }
 
-  if (nameLength > nameLengthLimit) {
+  if (nameLength > nameLengthLimit || errCode === 413) {
     nameAlertMsg = "名稱字數超出上限";
   }
 
-  // 使用者有輸入且不是空值的時候判斷字數
+  // 使用者有輸入密碼且不是空值的時候判斷字數
   if (
-    passwordLength > 0 &&
-    passwordLength < 4 &&
-    !isSpaceCheck.test(password)
+    (passwordLength > 0 &&
+      passwordLength < 4 &&
+      !isSpaceCheck.test(password)) ||
+    (passwordLength > 0 &&
+      passwordLength > 12 &&
+      !isSpaceCheck.test(password)) ||
+    errCode === 412
   ) {
-    passwordAlertMsg = "密碼不可小於4字元";
-  }
-
-  if (passwordLength > 12) {
-    passwordAlertMsg = "密碼不可多於12字元";
+    passwordAlertMsg = "密碼長度不符";
   }
 
   //wrong email format alert
-  if (emailLength > 0 && !emailRule.test(email)) {
+  if ((emailLength > 0 && !emailRule.test(email)) || errCode === 401) {
     emailAlertMsg = "Email格式錯誤";
   }
 
   //passwordCheck unmatched alert
-  if (checkPassword > 0 && checkPassword !== password) {
+  if ((checkPassword > 0 && checkPassword !== password) || errCode === 422) {
     checkPasswordAlertMsg = "密碼不相符";
   }
+
+  //後端驗證帳號重複
+  if (errCode === 423) {
+    accountAlertMsg = "帳號已重複註冊";
+  }
+
+  //後端驗證email重複
+  if (errCode === 408) {
+    emailAlertMsg = "Email已重複註冊";
+  }
+
+  // 以上為錯誤驗證------------------------------
 
   return (
     <div className={styles["container"]}>

--- a/src/Pages/RegisterPage/index.jsx
+++ b/src/Pages/RegisterPage/index.jsx
@@ -91,7 +91,8 @@ function RegisterPage() {
       ToastFail.fire({
         title: "有空白欄位！",
       });
-    } else if (!errCode) {
+    // errCode為500（其他錯誤）或是沒有catch到errCode的錯誤
+    } else if (errCode === 500 || !errCode) {
       ToastFail.fire({
         title: "發生未預期錯誤...",
       });

--- a/src/Pages/SettingPage/index.jsx
+++ b/src/Pages/SettingPage/index.jsx
@@ -1,4 +1,4 @@
-import { useState,useEffect } from "react";
+import { useState, useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 import UserSideBar from "../../Components/UserSideBar";
 import AuthInput from "../../Components/AuthInput";
@@ -68,14 +68,23 @@ function SettingPage() {
     }
     // If all input value is valid
     const nameTrimmed = name.trim();
-    const { success, errCode } = await setUserData({
-      id: currentUser.id,
-      account: account,
-      name: nameTrimmed,
-      email: email,
-      password: password,
-      checkPassword: checkPassword,
-    });
+    const id = currentUser.id
+    //打包資料成formData
+    let formData = new FormData();
+    formData.append("account", account);
+    formData.append("name", nameTrimmed);
+    formData.append("email", email);
+    formData.append("password", password);
+    formData.append("checkPassword", checkPassword);
+
+    for (let [name, value] of formData.entries()) {
+      console.log(name + ": " + value);
+    }
+    if(!formData) {
+      return
+    }
+
+    const { success, errCode } = await setUserData(id, formData);
     if (success) {
       ToastSuccess.fire({
         title: "更新成功！",
@@ -104,6 +113,7 @@ function SettingPage() {
   // When user focus on the input clear the alert message
   const handleFocus = () => {
     setSubmitting(false);
+    setErrCode("")
   };
 
   //if user is authenticated, navigate to home page

--- a/src/Pages/SettingPage/index.jsx
+++ b/src/Pages/SettingPage/index.jsx
@@ -96,7 +96,7 @@ function SettingPage() {
     // token驗證失敗
     if (errCode === 401) {
       ToastFail.fire({
-        title: "您尚未登入",
+        title: "帳號不存在！",
       });
       navigate("/login");
       // errCode為412（請求使用者id不存在）500（其他錯誤）或是沒有catch到errCode的錯誤

--- a/src/Pages/SettingPage/index.jsx
+++ b/src/Pages/SettingPage/index.jsx
@@ -68,7 +68,7 @@ function SettingPage() {
     }
     // If all input value is valid
     const nameTrimmed = name.trim();
-    const id = currentUser.id
+    const id = currentUser.id;
     //打包資料成formData
     let formData = new FormData();
     formData.append("account", account);
@@ -80,8 +80,8 @@ function SettingPage() {
     for (let [name, value] of formData.entries()) {
       console.log(name + ": " + value);
     }
-    if(!formData) {
-      return
+    if (!formData) {
+      return;
     }
 
     const { success, errCode } = await setUserData(id, formData);
@@ -113,12 +113,15 @@ function SettingPage() {
   // When user focus on the input clear the alert message
   const handleFocus = () => {
     setSubmitting(false);
-    setErrCode("")
+    setErrCode("");
   };
 
   //if user is authenticated, navigate to home page
   useEffect(() => {
     if (!isAuthenticated) {
+      ToastFail.fire({
+        title: "帳號不存在！",
+      });
       navigate("/login");
     }
   }, [navigate, isAuthenticated]);

--- a/src/assets/sweetalert.js
+++ b/src/assets/sweetalert.js
@@ -1,0 +1,24 @@
+import Swal from "sweetalert2";
+
+//成功訊息的樣式
+export const ToastSuccess = Swal.mixin({
+  color: "#000000",
+  icon: "success",
+  iconColor: "#82C43C",
+  toast: "true",
+  showConfirmButton: false,
+  timer: 1000,
+  position: "top",
+})
+
+// 失敗訊息的樣式
+export const ToastFail = Swal.mixin({
+  color: "#000000",
+  icon: "error",
+  iconColor: "#FC5A5A",
+  toast: "true",
+  width: "25%",
+  showConfirmButton: false,
+  timer: 1000,
+  position: "top",
+})

--- a/src/assets/sweetalert.js
+++ b/src/assets/sweetalert.js
@@ -17,7 +17,7 @@ export const ToastFail = Swal.mixin({
   icon: "error",
   iconColor: "#FC5A5A",
   toast: "true",
-  width: "25%",
+  width: "30%",
   showConfirmButton: false,
   timer: 1000,
   position: "top",


### PR DESCRIPTION
新增後端驗證錯誤訊息以及串接admin token驗證api如下：

＜前台登入頁面＞
- 如果帳號不存在（使用admin帳號登入等同於帳號不存在）或者是密碼錯誤，會顯示錯誤在輸入欄位下方

＜前台註冊頁面＞
- 如果email或帳號重複註冊，會顯示錯誤在輸入欄位下方

＜前台設定頁面＞
- 如果email或帳號重複註冊，會顯示錯誤在輸入欄位下方
- 如果使用者為未登入狀態或是admin帳號登入中狀態（token驗證失敗）會跳出錯誤訊息：「帳號不存在！」並導回登入頁

＜後台登入頁面＞
- 如果帳號不存在（使用一般user帳號登入等同於帳號不存在）或者是密碼錯誤，會顯示錯誤在輸入欄位下方
- 如果已經帶有admin帳號的token進到此頁面，會自動導向後台推文清單頁面

＜後台推文清單頁面、使用者列表頁面＞
-  如果使用者為未登入狀態或是非admin帳號登入中狀態（token驗證失敗）會跳出錯誤訊息：「帳號不存在！」並導回後台登入頁

其他：
- 將成功／失敗提示訊息的樣式統一