### PR TITLE
AP rev1(Fix - register/admin/setting page)

### DIFF
--- a/src/Context/AuthContext.js
+++ b/src/Context/AuthContext.js
@@ -81,7 +81,7 @@ function AuthProvider(props) {
         register: async (data) => {
           const { success, token, user, errCode } = await register({
             account: data.account,
-            name: data.nameTrimmed,
+            name: data.name,
             email: data.email,
             password: data.password,
             checkPassword: data.checkPassword

--- a/src/Context/AuthContext.js
+++ b/src/Context/AuthContext.js
@@ -2,6 +2,7 @@ import { createContext } from "react";
 import { useState, useEffect, useContext } from "react";
 import { useLocation } from 'react-router-dom';
 import { login, register, checkPermission, checkAdminPermission } from '../Api/AuthAPI'
+import { adminLogin } from "../Api/AdminAPI";
 
 // 設定一開始context 預設值
 const defaultValue = {
@@ -10,6 +11,7 @@ const defaultValue = {
   setCurrentUser: null, //更新使用者資料
   register: null, //註冊function
   login: null, //登入function
+  adminLogin: null,
   logout: null, // 登出function
 }
 
@@ -64,7 +66,7 @@ function AuthProvider(props) {
       }
     }
     // admin related pages not applied  
-    if (pathname.includes("/admin")) { checkAdminTokenIsValid() } 
+    if (pathname.includes("/admin")) { checkAdminTokenIsValid() }
     else {
       checkTokenIsValid()
     }
@@ -107,6 +109,17 @@ function AuthProvider(props) {
           localStorage.removeItem('authToken');
           setUserData(null);
           setIsAuthenticated(false);
+        },
+        adminLogin: async (data) => {
+          const { success, token, errCode } = await adminLogin({
+            account: data.account,
+            password: data.password,
+          });
+          if (token) {
+            setIsAuthenticated(true);
+            localStorage.setItem('authToken', token);
+          }
+          return { success, errCode }
         }
       }
     }>

--- a/src/Context/AuthContext.js
+++ b/src/Context/AuthContext.js
@@ -80,8 +80,8 @@ function AuthProvider(props) {
         setCurrentUser: setUserData, //傳給編輯使用者資料相關頁面使用
         register: async (data) => {
           const { success, token, user, errCode } = await register({
-            account: data.account,
-            name: data.name,
+            account: data.accountTrimmed,
+            name: data.nameTrimmed,
             email: data.email,
             password: data.password,
             checkPassword: data.checkPassword

--- a/src/Pages/AdminLoginPage/index.jsx
+++ b/src/Pages/AdminLoginPage/index.jsx
@@ -3,7 +3,7 @@ import { Link, useNavigate } from "react-router-dom";
 import { ReactComponent as AcLogo } from "../../assets/icons/AcLogo.svg";
 import AuthInput from "../../Components/AuthInput/index";
 import Button from "../../Components/Button";
-import { adminLogin } from "../../Api/AdminAPI";
+// import { adminLogin } from "../../Api/AdminAPI";
 import { useAuth } from "../../Context/AuthContext";
 import styles from "./AdminLoginPage.module.scss";
 import { ToastSuccess, ToastFail } from "../../assets/sweetalert"; //引入Toast樣式
@@ -16,7 +16,7 @@ function AdminLoginPage() {
   const [errCode, setErrCode] = useState("");
   const navigate = useNavigate();
 
-  const { isAuthenticated } = useAuth();
+  const { adminLogin, isAuthenticated } = useAuth();
 
   // Alert message variant
   let accountAlertMsg = "";
@@ -33,14 +33,12 @@ function AdminLoginPage() {
       return;
     }
     // If all input value is valid
-    const { success, token, errCode } = await adminLogin({
+    const { success, errCode } = await adminLogin({
       account,
       password,
     });
 
-    // 待後端把錯誤訊息補上補上實作錯誤訊息
     if (success) {
-      localStorage.setItem("authToken", token);
       ToastSuccess.fire({
         title: "登入成功！",
       });

--- a/src/Pages/AdminUserPage/index.jsx
+++ b/src/Pages/AdminUserPage/index.jsx
@@ -28,8 +28,12 @@ function AdminUserCard(props) {
         <img src={avatar} className={styles["avatar-img"]} alt="user-avatar" />
       </div>
       <div className={styles["user-info"]}>
-        <p className={styles["user-info-name"]}>{userName}</p>
-        <p className={styles["user-info-account"]}>@{account}</p>
+        <p className={styles["user-info-name"]}>
+          {userName.length > 18 ? userName.slice(0, 18) + "..." : userName}
+        </p>
+        <p className={styles["user-info-account"]}>
+          @{account.length > 18 ? account.slice(0, 18) + "..." : account}
+        </p>
       </div>
       <div className={styles["user-tweet-data"]}>
         <div className={styles["user-tweet-num"]}>
@@ -66,7 +70,7 @@ function AdminUserPage() {
         title: "帳號不存在！",
       });
       navigate("/admin");
-      return
+      return;
     }
   }, [navigate, isAuthenticated]);
 

--- a/src/Pages/RegisterPage/index.jsx
+++ b/src/Pages/RegisterPage/index.jsx
@@ -29,7 +29,7 @@ function RegisterPage() {
 
   // Word length related constant
   const accountLength = account.length;
-  const nameLength = name.trim().length;
+  const nameLength = name.length;
   const passwordLength = password.length;
   const emailLength = email.length;
   const checkPasswordLength = checkPassword.length;
@@ -68,10 +68,9 @@ function RegisterPage() {
     }
     // If all input value is valid
     // refactor the value of account and password
-    const nameTrimmed = name.trim();
     const { success, errCode } = await register({
       account,
-      nameTrimmed,
+      name,
       email,
       password,
       checkPassword,
@@ -91,7 +90,7 @@ function RegisterPage() {
       ToastFail.fire({
         title: "有空白欄位！",
       });
-    // errCode為500（其他錯誤）或是沒有catch到errCode的錯誤
+      // errCode為500（其他錯誤）或是沒有catch到errCode的錯誤
     } else if (errCode === 500 || !errCode) {
       ToastFail.fire({
         title: "發生未預期錯誤...",

--- a/src/Pages/RegisterPage/index.jsx
+++ b/src/Pages/RegisterPage/index.jsx
@@ -187,6 +187,11 @@ function RegisterPage() {
     emailAlertMsg = "Email已重複註冊";
   }
 
+  //後端驗證email和帳號同時重複
+  if (errCode === 405) {
+    accountAlertMsg = "帳號已重複註冊";
+    emailAlertMsg = "Email已重複註冊";
+  }
   // 以上為錯誤驗證------------------------------
 
   return (

--- a/src/Pages/RegisterPage/index.jsx
+++ b/src/Pages/RegisterPage/index.jsx
@@ -28,8 +28,8 @@ function RegisterPage() {
   let checkPasswordAlertMsg = "";
 
   // Word length related constant
-  const accountLength = account.length;
-  const nameLength = name.length;
+  const accountLength = account.trim().length;
+  const nameLength = name.trim().length;
   const passwordLength = password.length;
   const emailLength = email.length;
   const checkPasswordLength = checkPassword.length;
@@ -68,9 +68,11 @@ function RegisterPage() {
     }
     // If all input value is valid
     // refactor the value of account and password
+    const accountTrimmed = account.trim()
+    const nameTrimmed = name.trim()
     const { success, errCode } = await register({
-      account,
-      name,
+      accountTrimmed,
+      nameTrimmed,
       email,
       password,
       checkPassword,

--- a/src/Pages/SettingPage/index.jsx
+++ b/src/Pages/SettingPage/index.jsx
@@ -30,8 +30,8 @@ function SettingPage() {
   let checkPasswordAlertMsg = "";
 
   // Word length related constant
-  const accountLength = account?.length;
-  const nameLength = name?.length;
+  const accountLength = account?.trim().length;
+  const nameLength = name?.trim().length;
   const passwordLength = password?.length;
   const emailLength = email?.length;
   const accountLengthLimit = 50;
@@ -67,11 +67,13 @@ function SettingPage() {
       return;
     }
     // If all input value is valid
+    const accountTrimmed = account.trim();
+    const nameTrimmed = name.trim();
     const id = currentUser.id;
     //打包資料成formData
     let formData = new FormData();
-    formData.append("account", account);
-    formData.append("name", name);
+    formData.append("account", accountTrimmed);
+    formData.append("name", nameTrimmed);
     formData.append("email", email);
     formData.append("password", password);
     formData.append("checkPassword", checkPassword);

--- a/src/Pages/SettingPage/index.jsx
+++ b/src/Pages/SettingPage/index.jsx
@@ -162,9 +162,10 @@ function SettingPage() {
     (passwordLength > 0 &&
       passwordLength < 4 &&
       !isSpaceCheck.test(password)) ||
-    (passwordLength > 0 && passwordLength > 12 && !isSpaceCheck.test(password))
-    // 待後端修正
-    // errCode ===
+    (passwordLength > 0 &&
+      passwordLength > 12 &&
+      !isSpaceCheck.test(password)) ||
+    errCode === 422
   ) {
     passwordAlertMsg = "密碼長度不符";
   }
@@ -175,9 +176,7 @@ function SettingPage() {
   }
 
   //passwordCheck unmatched alert
-  if (checkPassword >= 0 && checkPassword !== password) {
-    // 待後端修正
-    // errCode ===
+  if ((checkPassword >= 0 && checkPassword !== password) || errCode === 407) {
     checkPasswordAlertMsg = "密碼不相符";
   }
 

--- a/src/Pages/SettingPage/index.jsx
+++ b/src/Pages/SettingPage/index.jsx
@@ -31,7 +31,7 @@ function SettingPage() {
 
   // Word length related constant
   const accountLength = account?.length;
-  const nameLength = name?.trim().length;
+  const nameLength = name?.length;
   const passwordLength = password?.length;
   const emailLength = email?.length;
   const accountLengthLimit = 50;
@@ -67,12 +67,11 @@ function SettingPage() {
       return;
     }
     // If all input value is valid
-    const nameTrimmed = name.trim();
     const id = currentUser.id;
     //打包資料成formData
     let formData = new FormData();
     formData.append("account", account);
-    formData.append("name", nameTrimmed);
+    formData.append("name", name);
     formData.append("email", email);
     formData.append("password", password);
     formData.append("checkPassword", checkPassword);
@@ -100,7 +99,7 @@ function SettingPage() {
       });
       navigate("/login");
       // errCode為412（請求使用者id不存在）500（其他錯誤）或是沒有catch到errCode的錯誤
-    } else if (errCode === 411 || errCode === 500 || !errCode) {
+    } else if (errCode === 412 || errCode === 500 || !errCode) {
       ToastFail.fire({
         title: "發生未預期錯誤...",
       });
@@ -120,7 +119,7 @@ function SettingPage() {
   useEffect(() => {
     if (!isAuthenticated) {
       ToastFail.fire({
-        title: "帳號不存在！",
+        title: "您尚未登入！",
       });
       navigate("/login");
     }

--- a/src/Pages/SettingPage/index.jsx
+++ b/src/Pages/SettingPage/index.jsx
@@ -76,13 +76,6 @@ function SettingPage() {
     formData.append("password", password);
     formData.append("checkPassword", checkPassword);
 
-    for (let [name, value] of formData.entries()) {
-      console.log(name + ": " + value);
-    }
-    if (!formData) {
-      return;
-    }
-
     const { success, errCode } = await setUserData(id, formData);
     if (success) {
       ToastSuccess.fire({

--- a/src/Pages/SettingPage/index.jsx
+++ b/src/Pages/SettingPage/index.jsx
@@ -190,6 +190,12 @@ function SettingPage() {
   if (errCode === 408) {
     emailAlertMsg = "Email已重複註冊";
   }
+
+  //後端驗證email和帳號同時重複
+  if (errCode === 405) {
+    accountAlertMsg = "帳號已重複註冊";
+    emailAlertMsg = "Email已重複註冊";
+  }
   // 以上為錯誤驗證------------------------------
 
   return (


### PR DESCRIPTION
此分支修正以下部分：

- 在註冊頁面以及設定頁面中，如果帳號與Email同時錯誤，錯誤訊息只會顯示在其中一個欄位，已更正為兩個欄位都會顯示錯誤
- 將帳號更改為空白鍵不計算字數（註冊頁面／設定頁面）
- 清除有console.log的部分
- 如果帳號或名稱太長，admin使用者列表中會出現爆版，已修正
- 後台登入後會跳出帳號不存在！的警示後登入，已修正